### PR TITLE
Add config name, config description and config kind fields

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -32,6 +32,10 @@ Configuration::Configuration(
 {
     displayUnits = units;
 
+    configName = QString("");
+    configDescription = QString("");
+    configKind = QString("");
+
     model = Airborne1G;
     rate = 200;
 

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -113,6 +113,10 @@ public:
 
     DisplayUnits displayUnits;
 
+    QString configName;
+    QString configDescription;
+    QString configKind;
+
     Model model;
     int   rate;
 

--- a/src/generalform.cpp
+++ b/src/generalform.cpp
@@ -59,6 +59,9 @@ void GeneralForm::setConfiguration(
         ui->modelComboBox->setCurrentIndex(configuration.model - 1);
     }
     ui->rateSpinBox->setValue(configuration.rate);
+    ui->confignameEdit->setText(configuration.configName);
+    ui->configdescriptionEdit->setText(configuration.configDescription);
+    ui->filekindEdit->setText(configuration.configKind);
 }
 
 void GeneralForm::updateConfiguration(
@@ -72,4 +75,7 @@ void GeneralForm::updateConfiguration(
     else        configuration.model = (Configuration::Model) (i + 1);
 
     configuration.rate = ui->rateSpinBox->value();
+    configuration.configName = ui->confignameEdit->text();
+    configuration.configDescription = ui->configdescriptionEdit->text();
+    configuration.configKind = ui->configkindEdit->text();
 }

--- a/src/generalform.ui
+++ b/src/generalform.ui
@@ -16,14 +16,14 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Sample period (ms):</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="4" column="1">
       <widget class="QSpinBox" name="rateSpinBox">
        <property name="minimum">
         <number>100</number>
@@ -39,15 +39,45 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Dynamic model:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="3" column="1">
       <widget class="QComboBox" name="modelComboBox"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Config kind:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="configkindEdit"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Config description:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="configdescriptionEdit"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Config name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="confignameEdit"/>
      </item>
     </layout>
    </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -208,6 +208,19 @@ if (!name.compare(s)) { (w) = (t) (val); }
 
 #undef HANDLE_VALUE
 
+        if (!name.compare("Config_Name"))
+        {
+            configuration.configName = result;
+        }
+        if (!name.compare("Config_Description"))
+        {
+            configuration.configDescription = result;
+        }
+        if (!name.compare("Config_Kind"))
+        {
+            configuration.configKind = result;
+        }
+
         if (!name.compare("Init_File"))
         {
             configuration.initFile = result;
@@ -293,6 +306,10 @@ bool MainWindow::saveFile(
     out << ";     http://flysight.ca/wiki" << endl << endl;
 
     out << "; GPS settings" << endl << endl;
+
+    out << "Config_Name:  " << configuration.configName.rightJustified(5) << " ; Configuration name" << endl;
+    out << "Config_Description:  " << configuration.configDescription.rightJustified(5) << " ; Configuration Description" << endl;
+    out << "Config_Kind:  " << configuration.configKind.rightJustified(5) << " ; Configuration kind. Allows to group configuration files together" << endl << endl;
 
     out << "Model:      " << QString("%1").arg(configuration.model, 5) << " ; Dynamic model" << endl;
     out << "                  ;   0 = Portable" << endl;


### PR DESCRIPTION
problematic : When we use multiple config files, knowing which one is loaded into CONFIG.TXT on out FlySight can be difficult. 
solution : Identifying a config with a name and a description could help the flysight user to know which file is being used, and also help third party applications to identify config files.

While discussing this with Mike, he suggested adding a description field also.

Bonus : I also added a config kind field. The idea is, if we use multiple files for, let's say, distance runs, and change only DZ_Elev in those files to support multiple dropzones, we could be able to modify Alarms on every configs of type "distance" on a single click instead of modifying alarms on each config file individually.

In a nutshell, this PR adds 3 fields to a config file :

Config name : Allows to identify a configuration when it is in use
Config description : Allows to add further information to identify the file
Config kind : Allows to group config files by kind